### PR TITLE
Crash with duplicate lines in the blocklist

### DIFF
--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -174,7 +174,7 @@ namespace EZBlocker
 
         private void ReadBlockList()
         {
-            m_blockList = File.ReadAllLines(blocklistPath).Select((k, v) => new { Index = k, Value = v }).ToDictionary(v => v.Index, v => v.Value);
+            m_blockList = File.ReadAllLines(blocklistPath).Distinct().Select((k, v) => new { Index = k, Value = v }).ToDictionary(v => v.Index, v => v.Value);
         }
 
         /**


### PR DESCRIPTION
If there are duplicate lines in the blocklist, the program crashes on
startup because the ReadBlockList method in Form1.cs tries to add
duplicate keys.
