### PR TITLE
Fixed muting issue on Windows 8

### DIFF
--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -202,7 +202,7 @@ namespace EZBlocker
             System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo();
             startInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
             startInfo.FileName = "cmd.exe";
-            startInfo.Arguments = "/C nircmdc muteappvolume spotify.exe " + i.ToString();
+            startInfo.Arguments = "/C nircmdc muteappvolume Spotify.exe " + i.ToString();
             process.StartInfo = startInfo;
             process.Start();
             if (i == 1)


### PR DESCRIPTION
Hey,

I was having issues with the Mute/UnMute button not working. I am running Windows 8 with the latest version of Spotify.

Anyways I played around with the nircmdc command and noticed that it only worked if spotify.exe is capitalized in the muteappvolume command. Anyone else having this issue? I am not sure if it is OS specific. 

Cheers,
P
