### PR TITLE
Preventing multiple instances from being started

### DIFF
--- a/EZBlocker/EZBlocker/EZBlocker.csproj
+++ b/EZBlocker/EZBlocker/EZBlocker.csproj
@@ -88,8 +88,6 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SpotifyAnswer.cs" />
-    <Compile Include="AudioUtilities.cs" />
-    <Compile Include="Volume.cs" />
     <EmbeddedResource Include="Blocklist.resx">
       <DependentUpon>Blocklist.cs</DependentUpon>
     </EmbeddedResource>

--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -293,14 +293,14 @@ namespace EZBlocker
             startInfo.FileName = "cmd.exe";
             if (spotifyMute)
             {
-                AudioUtilities.SetApplicationMute("spotify", muted);
-                /*startInfo.Arguments = "/C nircmd muteappvolume Spotify.exe " + i.ToString();
+                //AudioUtilities.SetApplicationMute("spotify", muted);
+                startInfo.Arguments = "/C nircmd muteappvolume Spotify.exe " + i.ToString();
                 process.StartInfo = startInfo;
                 process.Start();
                 // Run again for some users
                 startInfo.Arguments = "/C nircmd muteappvolume spotify.exe " + i.ToString();
                 process.StartInfo = startInfo;
-                process.Start();*/
+                process.Start();
             }
             else
             {
@@ -494,6 +494,26 @@ namespace EZBlocker
             {
                 return false;
             }
+        }
+
+        /**
+         * Processes window message and shows EZBlocker when attempting to launch a second instance.
+         **/
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == WindowUtilities.WM_SHOWAPP)
+            {
+                if (!this.ShowInTaskbar)
+                {
+                    this.WindowState = FormWindowState.Normal;
+                    this.ShowInTaskbar = true;
+                }
+                else
+                {
+                    this.Activate();
+                }
+            }
+            base.WndProc(ref m);
         }
 
         private void NotifyIcon_MouseDoubleClick(object sender, MouseEventArgs e)

--- a/EZBlocker/EZBlocker/Program.cs
+++ b/EZBlocker/EZBlocker/Program.cs
@@ -2,20 +2,40 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using System.Threading;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace EZBlocker
 {
     static class Program
     {
+        public static string appGuid =
+            ((GuidAttribute)Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(GuidAttribute), false).GetValue(0)).Value.ToString();
+
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         static void Main()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Main());
+            string mutexId = string.Format("Local\\{{{0}}}", appGuid); // unique id for local mutex
+
+            using (var mutex = new Mutex(false, mutexId))
+            {
+                if (mutex.WaitOne(TimeSpan.Zero))
+                {
+                    Application.EnableVisualStyles();
+                    Application.SetCompatibleTextRenderingDefault(false);
+                    Application.Run(new Main());
+                    mutex.ReleaseMutex();
+                }
+                else // another instance is already running
+                {
+                    WindowUtilities.ShowFirstInstance();
+                    return;
+                }
+            }
         }
     }
 }

--- a/EZBlocker/EZBlocker/WindowUtilities.cs
+++ b/EZBlocker/EZBlocker/WindowUtilities.cs
@@ -8,6 +8,10 @@ namespace EZBlocker
 {
     public static class WindowUtilities
     {
+        private const int HWND_BROADCAST = 0xffff;
+        public static readonly int WM_SHOWAPP =
+            RegisterWindowMessage("WM_SHOWAPP|{0}", Program.appGuid); // register unique window message
+
         private delegate bool EnumWindowsProc(IntPtr windowHandle, IntPtr lParam);
 
         [DllImport("user32")]
@@ -19,6 +23,12 @@ namespace EZBlocker
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam, uint fuFlags, uint uTimeout, out IntPtr lpdwResult);
         
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern bool SendNotifyMessage(IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32")]
+        private static extern int RegisterWindowMessage(string message);
+
         [DllImport("user32.dll", SetLastError = true)]
         static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
@@ -72,5 +82,19 @@ namespace EZBlocker
             return match;
         }
 
+        private static int RegisterWindowMessage(string format, params object[] args)
+        {
+            string message = String.Format(format, args);
+            return RegisterWindowMessage(message);
+        }
+
+        public static void ShowFirstInstance()
+        {
+            SendNotifyMessage(
+                (IntPtr)HWND_BROADCAST,
+                (uint)WM_SHOWAPP,
+                UIntPtr.Zero,
+                IntPtr.Zero);
+        }
     }
 }


### PR DESCRIPTION
Hi there,

I added some code to fix #20 . Instead of launching a second instance, the program will now simply switch to the instance that was already running. It works by using a Mutex object to allow a single instance and a Window Message to bring the running instance to the front.

Cheers,
B
