### PR TITLE
Hide EZBlocker from Alt-Tab when minimized (proper)

### DIFF
--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -338,6 +338,13 @@ namespace EZBlocker
             }
         }
 
+        private void RestoreFromTaskbar()
+        {
+            this.WindowState = FormWindowState.Normal;
+            this.ShowInTaskbar = true;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+        }
+        
         /**
          * Processes window message and shows EZBlocker when attempting to launch a second instance.
          **/
@@ -347,8 +354,7 @@ namespace EZBlocker
             {
                 if (!this.ShowInTaskbar)
                 {
-                    this.WindowState = FormWindowState.Normal;
-                    this.ShowInTaskbar = true;
+                    RestoreFromTaskbar();
                 }
                 else
                 {
@@ -367,15 +373,13 @@ namespace EZBlocker
         {
             if (!this.ShowInTaskbar)
             {
-                this.WindowState = FormWindowState.Normal;
-                this.ShowInTaskbar = true;
+                RestoreFromTaskbar();
             }
         }
 
         private void NotifyIcon_BalloonTipClicked(object sender, EventArgs e)
         {
-            this.WindowState = FormWindowState.Normal;
-            this.ShowInTaskbar = true;
+            RestoreFromTaskbar();
         }
 
         private void Form_Resize(object sender, EventArgs e)
@@ -383,6 +387,7 @@ namespace EZBlocker
             if (this.WindowState == FormWindowState.Minimized)
             {
                 this.ShowInTaskbar = false;
+                this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
                 Notify("EZBlocker is hidden. Double-click this icon to restore.");
             }
         }

--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -338,7 +338,7 @@ namespace EZBlocker
             }
         }
 
-        private void RestoreFromTaskbar()
+        private void RestoreFromTray()
         {
             this.WindowState = FormWindowState.Normal;
             this.ShowInTaskbar = true;
@@ -354,7 +354,7 @@ namespace EZBlocker
             {
                 if (!this.ShowInTaskbar)
                 {
-                    RestoreFromTaskbar();
+                    RestoreFromTray();
                 }
                 else
                 {
@@ -373,13 +373,13 @@ namespace EZBlocker
         {
             if (!this.ShowInTaskbar)
             {
-                RestoreFromTaskbar();
+                RestoreFromTray();
             }
         }
 
         private void NotifyIcon_BalloonTipClicked(object sender, EventArgs e)
         {
-            RestoreFromTaskbar();
+            RestoreFromTray();
         }
 
         private void Form_Resize(object sender, EventArgs e)


### PR DESCRIPTION
The same idea like #29, but FormBorderStyle is changed when EZBlocker is being minimized/maximized.

This solution does not remove the minimize button from the application window.