### PR TITLE
Disables "EZBlocker is hidden" Balloon Tip

### DIFF
--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -382,7 +382,8 @@ namespace EZBlocker
             {
                 this.ShowInTaskbar = false;
                 this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-                Notify("EZBlocker is hidden. Double-click this icon to restore.");
+                // Very Annoying
+                // Notify("EZBlocker is hidden. Double-click this icon to restore.");
             }
         }
 


### PR DESCRIPTION
This Disables the super annoying  "EZBlocker is hidden" Balloon Tip that is shown every time EZBlocker is minimized.
