### PR TITLE
Fixed Small Icon Bug

### DIFF
--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -421,6 +421,10 @@ namespace EZBlocker
                 this.FormBorderStyle = FormBorderStyle.FixedToolWindow;
                 Notify("EZBlocker is hidden. Double-click this icon to restore.");
             }
+            if (this.WindowState == FormWindowState.Normal)
+            {
+                this.FormBorderStyle = FormBorderStyle.FixedSingle;
+            }
         }
 
         private void SpotifyMuteCheckBox_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
Icon was not appearing after reopening EZBlocker from the system tray.
This was fixed by setting the FormBorderStyle back to its default value
of FixedSingle whenever the WindowState is set to Normal.

Before minimize to system tray:
![1](https://cloud.githubusercontent.com/assets/13220308/19425423/e3f70d08-93f7-11e6-9735-b6d35fd64e24.PNG)

After reopening from system tray: 
![2](https://cloud.githubusercontent.com/assets/13220308/19425427/ea092672-93f7-11e6-981e-d50d811e4a4a.PNG)

