### PR TITLE
Fixed Small Icon Bug

### DIFF
--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -370,9 +370,9 @@ namespace EZBlocker
 
         private void RestoreFromTray()
         {
+            this.FormBorderStyle = FormBorderStyle.FixedSingle;
             this.WindowState = FormWindowState.Normal;
             this.ShowInTaskbar = true;
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
         }
         
         /**


### PR DESCRIPTION
Icon was not appearing after reopening EZBlocker from the system tray.
This was happening because of the order of the RestoreFromTray method. 
Also simplified the code.  

Before minimized to system tray:
![1](https://cloud.githubusercontent.com/assets/13220308/19459028/e02f29e6-9495-11e6-86ce-d38354c12b05.PNG)

After opened from system tray: 
![2](https://cloud.githubusercontent.com/assets/13220308/19459035/e8616ab6-9495-11e6-87d8-2bd9203d9561.PNG)
