### PR TITLE
Adds handling of expired OAuth token.

### DIFF
--- a/EZBlocker/EZBlocker/WebHelperHook.cs
+++ b/EZBlocker/EZBlocker/WebHelperHook.cs
@@ -99,6 +99,11 @@ namespace EZBlocker
                         Debug.WriteLine("Invalid OAuth token");
                         SetOAuth();
                     }
+                    else if (line.Contains("Expired OAuth token"))
+                    {
+                        Debug.WriteLine("Expired OAuth token");
+                        SetOAuth();
+                    }
                 }
             }
 


### PR DESCRIPTION
If you have ezblocker running before hibernating the computer, ezblocker will hang the next time you start up if the computer was in hibernation for a day or so.