### PR TITLE
Added a checkbox to exit when Spotify closes or not.

### DIFF
--- a/EZBlocker/EZBlocker/App.config
+++ b/EZBlocker/EZBlocker/App.config
@@ -25,6 +25,9 @@
             <setting name="ExitOnClose" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="DisableNotifs" serializeAs="String">
+                <value>False</value>
+            </setting>
         </EZBlocker.Properties.Settings>
     </userSettings>
 </configuration>

--- a/EZBlocker/EZBlocker/App.config
+++ b/EZBlocker/EZBlocker/App.config
@@ -22,6 +22,9 @@
             <setting name="UserEducated" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="ExitOnClose" serializeAs="String">
+                <value>True</value>
+            </setting>
         </EZBlocker.Properties.Settings>
     </userSettings>
 </configuration>

--- a/EZBlocker/EZBlocker/Form1.Designer.cs
+++ b/EZBlocker/EZBlocker/Form1.Designer.cs
@@ -31,7 +31,6 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Main));
             this.MainTimer = new System.Windows.Forms.Timer(this.components);
-            this.MuteButton = new System.Windows.Forms.Button();
             this.NotifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.NotifyIconContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -46,6 +45,7 @@
             this.BlockBannersCheckbox = new System.Windows.Forms.CheckBox();
             this.StartupCheckbox = new System.Windows.Forms.CheckBox();
             this.ExitOnCloseCheckbox = new System.Windows.Forms.CheckBox();
+            this.DisableNotificationsCheckbox = new System.Windows.Forms.CheckBox();
             this.NotifyIconContextMenu.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -53,18 +53,6 @@
             // 
             this.MainTimer.Interval = 600;
             this.MainTimer.Tick += new System.EventHandler(this.MainTimer_Tick);
-            // 
-            // MuteButton
-            // 
-            this.MuteButton.Location = new System.Drawing.Point(16, 217);
-            this.MuteButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.MuteButton.Name = "MuteButton";
-            this.MuteButton.Size = new System.Drawing.Size(79, 33);
-            this.MuteButton.TabIndex = 3;
-            this.MuteButton.Text = "Mute/UnMute Spotify";
-            this.MuteButton.UseVisualStyleBackColor = true;
-            this.MuteButton.Visible = false;
-            this.MuteButton.Click += new System.EventHandler(this.MuteButton_Click);
             // 
             // NotifyIcon
             // 
@@ -84,41 +72,40 @@
             this.separatorToolStripMenuItem,
             this.exitToolStripMenuItem});
             this.NotifyIconContextMenu.Name = "NotifyIconContextMenu";
-            this.NotifyIconContextMenu.Size = new System.Drawing.Size(132, 82);
+            this.NotifyIconContextMenu.Size = new System.Drawing.Size(117, 76);
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(131, 24);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
             this.openToolStripMenuItem.Text = "Open";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
             // websiteToolStripMenuItem
             // 
             this.websiteToolStripMenuItem.Name = "websiteToolStripMenuItem";
-            this.websiteToolStripMenuItem.Size = new System.Drawing.Size(131, 24);
+            this.websiteToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
             this.websiteToolStripMenuItem.Text = "Website";
             this.websiteToolStripMenuItem.Click += new System.EventHandler(this.websiteToolStripMenuItem_Click);
             // 
             // separatorToolStripMenuItem
             // 
             this.separatorToolStripMenuItem.Name = "separatorToolStripMenuItem";
-            this.separatorToolStripMenuItem.Size = new System.Drawing.Size(128, 6);
+            this.separatorToolStripMenuItem.Size = new System.Drawing.Size(113, 6);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(131, 24);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
             this.exitToolStripMenuItem.Text = "&Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
             // WebsiteLink
             // 
             this.WebsiteLink.AutoSize = true;
-            this.WebsiteLink.Location = new System.Drawing.Point(192, 170);
-            this.WebsiteLink.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.WebsiteLink.Location = new System.Drawing.Point(144, 160);
             this.WebsiteLink.Name = "WebsiteLink";
-            this.WebsiteLink.Size = new System.Drawing.Size(107, 17);
+            this.WebsiteLink.Size = new System.Drawing.Size(80, 13);
             this.WebsiteLink.TabIndex = 5;
             this.WebsiteLink.TabStop = true;
             this.WebsiteLink.Text = "Report Problem";
@@ -133,10 +120,9 @@
             // SpotifyMuteCheckbox
             // 
             this.SpotifyMuteCheckbox.AutoSize = true;
-            this.SpotifyMuteCheckbox.Location = new System.Drawing.Point(16, 59);
-            this.SpotifyMuteCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.SpotifyMuteCheckbox.Location = new System.Drawing.Point(12, 48);
             this.SpotifyMuteCheckbox.Name = "SpotifyMuteCheckbox";
-            this.SpotifyMuteCheckbox.Size = new System.Drawing.Size(141, 21);
+            this.SpotifyMuteCheckbox.Size = new System.Drawing.Size(109, 17);
             this.SpotifyMuteCheckbox.TabIndex = 6;
             this.SpotifyMuteCheckbox.Text = "Mute Only Spotify";
             this.SpotifyMuteCheckbox.UseVisualStyleBackColor = true;
@@ -144,10 +130,9 @@
             // 
             // VolumeMixerButton
             // 
-            this.VolumeMixerButton.Location = new System.Drawing.Point(16, 7);
-            this.VolumeMixerButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.VolumeMixerButton.Location = new System.Drawing.Point(12, 6);
             this.VolumeMixerButton.Name = "VolumeMixerButton";
-            this.VolumeMixerButton.Size = new System.Drawing.Size(283, 44);
+            this.VolumeMixerButton.Size = new System.Drawing.Size(212, 36);
             this.VolumeMixerButton.TabIndex = 7;
             this.VolumeMixerButton.Text = "Open Volume Mixer";
             this.VolumeMixerButton.UseVisualStyleBackColor = true;
@@ -157,20 +142,18 @@
             // 
             this.StatusLabel.AutoSize = true;
             this.StatusLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.StatusLabel.Location = new System.Drawing.Point(12, 170);
-            this.StatusLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.StatusLabel.Location = new System.Drawing.Point(9, 160);
             this.StatusLabel.Name = "StatusLabel";
-            this.StatusLabel.Size = new System.Drawing.Size(71, 17);
+            this.StatusLabel.Size = new System.Drawing.Size(54, 13);
             this.StatusLabel.TabIndex = 9;
             this.StatusLabel.Text = "Loading...";
             // 
             // BlockBannersCheckbox
             // 
             this.BlockBannersCheckbox.AutoSize = true;
-            this.BlockBannersCheckbox.Location = new System.Drawing.Point(16, 87);
-            this.BlockBannersCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.BlockBannersCheckbox.Location = new System.Drawing.Point(12, 71);
             this.BlockBannersCheckbox.Name = "BlockBannersCheckbox";
-            this.BlockBannersCheckbox.Size = new System.Drawing.Size(219, 21);
+            this.BlockBannersCheckbox.Size = new System.Drawing.Size(165, 17);
             this.BlockBannersCheckbox.TabIndex = 10;
             this.BlockBannersCheckbox.Text = "Disable All Ads (Experimental)";
             this.BlockBannersCheckbox.UseVisualStyleBackColor = true;
@@ -179,10 +162,9 @@
             // StartupCheckbox
             // 
             this.StartupCheckbox.AutoSize = true;
-            this.StartupCheckbox.Location = new System.Drawing.Point(16, 116);
-            this.StartupCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.StartupCheckbox.Location = new System.Drawing.Point(12, 94);
             this.StartupCheckbox.Name = "StartupCheckbox";
-            this.StartupCheckbox.Size = new System.Drawing.Size(188, 21);
+            this.StartupCheckbox.Size = new System.Drawing.Size(145, 17);
             this.StartupCheckbox.TabIndex = 11;
             this.StartupCheckbox.Text = "Start EZBlocker on Login";
             this.StartupCheckbox.UseVisualStyleBackColor = true;
@@ -191,20 +173,31 @@
             // ExitOnCloseCheckbox
             // 
             this.ExitOnCloseCheckbox.AutoSize = true;
-            this.ExitOnCloseCheckbox.Location = new System.Drawing.Point(15, 145);
-            this.ExitOnCloseCheckbox.Margin = new System.Windows.Forms.Padding(4);
+            this.ExitOnCloseCheckbox.Location = new System.Drawing.Point(11, 118);
             this.ExitOnCloseCheckbox.Name = "ExitOnCloseCheckbox";
-            this.ExitOnCloseCheckbox.Size = new System.Drawing.Size(180, 21);
+            this.ExitOnCloseCheckbox.Size = new System.Drawing.Size(140, 17);
             this.ExitOnCloseCheckbox.TabIndex = 12;
             this.ExitOnCloseCheckbox.Text = "Exit when Spotify closes";
             this.ExitOnCloseCheckbox.UseVisualStyleBackColor = true;
             this.ExitOnCloseCheckbox.CheckedChanged += new System.EventHandler(this.ExitOnCloseCheckbox_CheckedChanged);
             // 
+            // DisableNotificationsCheckbox
+            // 
+            this.DisableNotificationsCheckbox.AutoSize = true;
+            this.DisableNotificationsCheckbox.Location = new System.Drawing.Point(11, 141);
+            this.DisableNotificationsCheckbox.Name = "DisableNotificationsCheckbox";
+            this.DisableNotificationsCheckbox.Size = new System.Drawing.Size(120, 17);
+            this.DisableNotificationsCheckbox.TabIndex = 13;
+            this.DisableNotificationsCheckbox.Text = "Disable notifications";
+            this.DisableNotificationsCheckbox.UseVisualStyleBackColor = true;
+            this.DisableNotificationsCheckbox.CheckedChanged += new System.EventHandler(this.DisableNotificationsCheckbox_CheckedChanged);
+            // 
             // Main
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(307, 198);
+            this.ClientSize = new System.Drawing.Size(230, 179);
+            this.Controls.Add(this.DisableNotificationsCheckbox);
             this.Controls.Add(this.ExitOnCloseCheckbox);
             this.Controls.Add(this.StartupCheckbox);
             this.Controls.Add(this.BlockBannersCheckbox);
@@ -212,11 +205,9 @@
             this.Controls.Add(this.VolumeMixerButton);
             this.Controls.Add(this.SpotifyMuteCheckbox);
             this.Controls.Add(this.WebsiteLink);
-            this.Controls.Add(this.MuteButton);
             this.Cursor = System.Windows.Forms.Cursors.Default;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.Name = "Main";
             this.RightToLeftLayout = true;
@@ -231,8 +222,6 @@
         }
 
         #endregion
-
-        private System.Windows.Forms.Button MuteButton;
         private System.Windows.Forms.NotifyIcon NotifyIcon;
         private System.Windows.Forms.LinkLabel WebsiteLink;
         private System.Windows.Forms.Timer Heartbeat;
@@ -248,6 +237,7 @@
         private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem websiteToolStripMenuItem;
         private System.Windows.Forms.CheckBox ExitOnCloseCheckbox;
+        private System.Windows.Forms.CheckBox DisableNotificationsCheckbox;
     }
 }
 

--- a/EZBlocker/EZBlocker/Form1.Designer.cs
+++ b/EZBlocker/EZBlocker/Form1.Designer.cs
@@ -35,6 +35,7 @@
             this.NotifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.NotifyIconContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.websiteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.separatorToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.WebsiteLink = new System.Windows.Forms.LinkLabel();
@@ -44,7 +45,7 @@
             this.StatusLabel = new System.Windows.Forms.Label();
             this.BlockBannersCheckbox = new System.Windows.Forms.CheckBox();
             this.StartupCheckbox = new System.Windows.Forms.CheckBox();
-            this.websiteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ExitOnCloseCheckbox = new System.Windows.Forms.CheckBox();
             this.NotifyIconContextMenu.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -55,9 +56,10 @@
             // 
             // MuteButton
             // 
-            this.MuteButton.Location = new System.Drawing.Point(12, 162);
+            this.MuteButton.Location = new System.Drawing.Point(16, 217);
+            this.MuteButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MuteButton.Name = "MuteButton";
-            this.MuteButton.Size = new System.Drawing.Size(59, 27);
+            this.MuteButton.Size = new System.Drawing.Size(79, 33);
             this.MuteButton.TabIndex = 3;
             this.MuteButton.Text = "Mute/UnMute Spotify";
             this.MuteButton.UseVisualStyleBackColor = true;
@@ -75,39 +77,48 @@
             // 
             // NotifyIconContextMenu
             // 
+            this.NotifyIconContextMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.NotifyIconContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.openToolStripMenuItem,
             this.websiteToolStripMenuItem,
             this.separatorToolStripMenuItem,
             this.exitToolStripMenuItem});
             this.NotifyIconContextMenu.Name = "NotifyIconContextMenu";
-            this.NotifyIconContextMenu.Size = new System.Drawing.Size(153, 98);
+            this.NotifyIconContextMenu.Size = new System.Drawing.Size(132, 82);
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(131, 24);
             this.openToolStripMenuItem.Text = "Open";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
+            // 
+            // websiteToolStripMenuItem
+            // 
+            this.websiteToolStripMenuItem.Name = "websiteToolStripMenuItem";
+            this.websiteToolStripMenuItem.Size = new System.Drawing.Size(131, 24);
+            this.websiteToolStripMenuItem.Text = "Website";
+            this.websiteToolStripMenuItem.Click += new System.EventHandler(this.websiteToolStripMenuItem_Click);
             // 
             // separatorToolStripMenuItem
             // 
             this.separatorToolStripMenuItem.Name = "separatorToolStripMenuItem";
-            this.separatorToolStripMenuItem.Size = new System.Drawing.Size(149, 6);
+            this.separatorToolStripMenuItem.Size = new System.Drawing.Size(128, 6);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(131, 24);
             this.exitToolStripMenuItem.Text = "&Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
             // WebsiteLink
             // 
             this.WebsiteLink.AutoSize = true;
-            this.WebsiteLink.Location = new System.Drawing.Point(144, 117);
+            this.WebsiteLink.Location = new System.Drawing.Point(192, 170);
+            this.WebsiteLink.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.WebsiteLink.Name = "WebsiteLink";
-            this.WebsiteLink.Size = new System.Drawing.Size(80, 13);
+            this.WebsiteLink.Size = new System.Drawing.Size(107, 17);
             this.WebsiteLink.TabIndex = 5;
             this.WebsiteLink.TabStop = true;
             this.WebsiteLink.Text = "Report Problem";
@@ -122,9 +133,10 @@
             // SpotifyMuteCheckbox
             // 
             this.SpotifyMuteCheckbox.AutoSize = true;
-            this.SpotifyMuteCheckbox.Location = new System.Drawing.Point(12, 48);
+            this.SpotifyMuteCheckbox.Location = new System.Drawing.Point(16, 59);
+            this.SpotifyMuteCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.SpotifyMuteCheckbox.Name = "SpotifyMuteCheckbox";
-            this.SpotifyMuteCheckbox.Size = new System.Drawing.Size(109, 17);
+            this.SpotifyMuteCheckbox.Size = new System.Drawing.Size(141, 21);
             this.SpotifyMuteCheckbox.TabIndex = 6;
             this.SpotifyMuteCheckbox.Text = "Mute Only Spotify";
             this.SpotifyMuteCheckbox.UseVisualStyleBackColor = true;
@@ -132,9 +144,10 @@
             // 
             // VolumeMixerButton
             // 
-            this.VolumeMixerButton.Location = new System.Drawing.Point(12, 6);
+            this.VolumeMixerButton.Location = new System.Drawing.Point(16, 7);
+            this.VolumeMixerButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.VolumeMixerButton.Name = "VolumeMixerButton";
-            this.VolumeMixerButton.Size = new System.Drawing.Size(212, 36);
+            this.VolumeMixerButton.Size = new System.Drawing.Size(283, 44);
             this.VolumeMixerButton.TabIndex = 7;
             this.VolumeMixerButton.Text = "Open Volume Mixer";
             this.VolumeMixerButton.UseVisualStyleBackColor = true;
@@ -144,18 +157,20 @@
             // 
             this.StatusLabel.AutoSize = true;
             this.StatusLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.StatusLabel.Location = new System.Drawing.Point(9, 117);
+            this.StatusLabel.Location = new System.Drawing.Point(12, 170);
+            this.StatusLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.StatusLabel.Name = "StatusLabel";
-            this.StatusLabel.Size = new System.Drawing.Size(54, 13);
+            this.StatusLabel.Size = new System.Drawing.Size(71, 17);
             this.StatusLabel.TabIndex = 9;
             this.StatusLabel.Text = "Loading...";
             // 
             // BlockBannersCheckbox
             // 
             this.BlockBannersCheckbox.AutoSize = true;
-            this.BlockBannersCheckbox.Location = new System.Drawing.Point(12, 71);
+            this.BlockBannersCheckbox.Location = new System.Drawing.Point(16, 87);
+            this.BlockBannersCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.BlockBannersCheckbox.Name = "BlockBannersCheckbox";
-            this.BlockBannersCheckbox.Size = new System.Drawing.Size(165, 17);
+            this.BlockBannersCheckbox.Size = new System.Drawing.Size(219, 21);
             this.BlockBannersCheckbox.TabIndex = 10;
             this.BlockBannersCheckbox.Text = "Disable All Ads (Experimental)";
             this.BlockBannersCheckbox.UseVisualStyleBackColor = true;
@@ -164,26 +179,33 @@
             // StartupCheckbox
             // 
             this.StartupCheckbox.AutoSize = true;
-            this.StartupCheckbox.Location = new System.Drawing.Point(12, 94);
+            this.StartupCheckbox.Location = new System.Drawing.Point(16, 116);
+            this.StartupCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.StartupCheckbox.Name = "StartupCheckbox";
-            this.StartupCheckbox.Size = new System.Drawing.Size(145, 17);
+            this.StartupCheckbox.Size = new System.Drawing.Size(188, 21);
             this.StartupCheckbox.TabIndex = 11;
             this.StartupCheckbox.Text = "Start EZBlocker on Login";
             this.StartupCheckbox.UseVisualStyleBackColor = true;
             this.StartupCheckbox.CheckedChanged += new System.EventHandler(this.StartupCheckbox_CheckedChanged);
             // 
-            // websiteToolStripMenuItem
+            // ExitOnCloseCheckbox
             // 
-            this.websiteToolStripMenuItem.Name = "websiteToolStripMenuItem";
-            this.websiteToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.websiteToolStripMenuItem.Text = "Website";
-            this.websiteToolStripMenuItem.Click += new System.EventHandler(this.websiteToolStripMenuItem_Click);
+            this.ExitOnCloseCheckbox.AutoSize = true;
+            this.ExitOnCloseCheckbox.Location = new System.Drawing.Point(15, 145);
+            this.ExitOnCloseCheckbox.Margin = new System.Windows.Forms.Padding(4);
+            this.ExitOnCloseCheckbox.Name = "ExitOnCloseCheckbox";
+            this.ExitOnCloseCheckbox.Size = new System.Drawing.Size(180, 21);
+            this.ExitOnCloseCheckbox.TabIndex = 12;
+            this.ExitOnCloseCheckbox.Text = "Exit when Spotify closes";
+            this.ExitOnCloseCheckbox.UseVisualStyleBackColor = true;
+            this.ExitOnCloseCheckbox.CheckedChanged += new System.EventHandler(this.ExitOnCloseCheckbox_CheckedChanged);
             // 
             // Main
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(230, 139);
+            this.ClientSize = new System.Drawing.Size(307, 198);
+            this.Controls.Add(this.ExitOnCloseCheckbox);
             this.Controls.Add(this.StartupCheckbox);
             this.Controls.Add(this.BlockBannersCheckbox);
             this.Controls.Add(this.StatusLabel);
@@ -194,6 +216,7 @@
             this.Cursor = System.Windows.Forms.Cursors.Default;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.Name = "Main";
             this.RightToLeftLayout = true;
@@ -224,6 +247,7 @@
         private System.Windows.Forms.ToolStripSeparator separatorToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem websiteToolStripMenuItem;
+        private System.Windows.Forms.CheckBox ExitOnCloseCheckbox;
     }
 }
 

--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -349,7 +349,7 @@ namespace EZBlocker
                     int releaseKey = Convert.ToInt32(ndpKey.GetValue("Release"));
                     if (releaseKey >= 378389) return true;
                 }
-            } catch (Exception ignore) {}
+            } catch (Exception) {}
             return false;
         }
 
@@ -512,7 +512,7 @@ namespace EZBlocker
                 Process.Start(volumeMixerPath);
                 LogAction("/button/volumemixer");
             }
-            catch (Exception ignore)
+            catch (Exception)
             {
                 MessageBox.Show("Could not open Volume Mixer. This is only available on Windows 7/8/10", "EZBlocker");
             }
@@ -559,34 +559,37 @@ namespace EZBlocker
 
             CheckUpdate();
 
-            // Start Spotify and give EZBlocker higher priority
-            try
-            {
-                if (File.Exists(spotifyPath) && Process.GetProcessesByName("spotify").Length < 1)
-                {
-                    Process.Start(spotifyPath);
-                }
-                Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.High; // Windows throttles down when minimized to task tray, so make sure EZBlocker runs smoothly
+            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.High; // Windows throttles down when minimized to task tray, so make sure EZBlocker runs smoothly
 
-                // Check for open.spotify.com in hosts
-                String hostsContent = File.ReadAllText(hostsPath);
-                if (hostsContent.Contains("open.spotify.com"))
+            if (exitOnClose)
+            {
+                try
                 {
-                    if (IsUserAnAdmin())
+                    if (File.Exists(spotifyPath) && Process.GetProcessesByName("spotify").Length < 1)
                     {
-                        File.WriteAllText(hostsPath, hostsContent.Replace("open.spotify.com", "localhost"));
-                        MessageBox.Show("An EZBlocker patch has been applied to your hosts file. If EZBlocker is stuck at 'Loading', please restart your computer.", "EZBlocker", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        Process.Start(spotifyPath);
                     }
-                    else
+
+                    // Check for open.spotify.com in hosts
+                    String hostsContent = File.ReadAllText(hostsPath);
+                    if (hostsContent.Contains("open.spotify.com"))
                     {
-                        MessageBox.Show("EZBlocker has detected an error in your hosts file.\r\n\r\nPlease re-run EZBlocker as Administrator or remove 'open.spotify.com' from your hosts file.", "EZBlocker", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                        Application.Exit();
+                        if (IsUserAnAdmin())
+                        {
+                            File.WriteAllText(hostsPath, hostsContent.Replace("open.spotify.com", "localhost"));
+                            MessageBox.Show("An EZBlocker patch has been applied to your hosts file. If EZBlocker is stuck at 'Loading', please restart your computer.", "EZBlocker", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        }
+                        else
+                        {
+                            MessageBox.Show("EZBlocker has detected an error in your hosts file.\r\n\r\nPlease re-run EZBlocker as Administrator or remove 'open.spotify.com' from your hosts file.", "EZBlocker", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            Application.Exit();
+                        }
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex);
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
             }
 
             // Extract dependencies

--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -728,18 +728,21 @@ namespace EZBlocker
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
-            if (!Properties.Settings.Default.UserEducated)
+            if (exitOnClose)
             {
-                var result = MessageBox.Show("Spotify ads will not be muted if EZBlocker is not running.\r\n\r\nAre you sure you want to exit?", "EZBlocker",
-                                 MessageBoxButtons.YesNo,
-                                 MessageBoxIcon.Warning);
-
-                e.Cancel = (result == DialogResult.No);
-
-                if (result == DialogResult.Yes)
+                if (!Properties.Settings.Default.UserEducated)
                 {
-                    Properties.Settings.Default.UserEducated = true;
-                    Properties.Settings.Default.Save();
+                    var result = MessageBox.Show("Spotify ads will not be muted if EZBlocker is not running.\r\n\r\nAre you sure you want to exit?", "EZBlocker",
+                                     MessageBoxButtons.YesNo,
+                                     MessageBoxIcon.Warning);
+
+                    e.Cancel = (result == DialogResult.No);
+
+                    if (result == DialogResult.Yes)
+                    {
+                        Properties.Settings.Default.UserEducated = true;
+                        Properties.Settings.Default.Save();
+                    }
                 }
             }
         }

--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -611,6 +611,7 @@ namespace EZBlocker
 
             // Set up UI
             SpotifyMuteCheckbox.Checked = Properties.Settings.Default.SpotifyMute;
+            ExitOnCloseCheckbox.Checked = Properties.Settings.Default.ExitOnClose;
             if (File.Exists(hostsPath))
             {
                 string hostsFile = File.ReadAllText(hostsPath);

--- a/EZBlocker/EZBlocker/Properties/Settings.Designer.cs
+++ b/EZBlocker/EZBlocker/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace EZBlocker.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -80,6 +80,18 @@ namespace EZBlocker.Properties {
             }
             set {
                 this["ExitOnClose"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool DisableNotifs {
+            get {
+                return ((bool)(this["DisableNotifs"]));
+            }
+            set {
+                this["DisableNotifs"] = value;
             }
         }
     }

--- a/EZBlocker/EZBlocker/Properties/Settings.Designer.cs
+++ b/EZBlocker/EZBlocker/Properties/Settings.Designer.cs
@@ -70,5 +70,17 @@ namespace EZBlocker.Properties {
                 this["UserEducated"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ExitOnClose {
+            get {
+                return ((bool)(this["ExitOnClose"]));
+            }
+            set {
+                this["ExitOnClose"] = value;
+            }
+        }
     }
 }

--- a/EZBlocker/EZBlocker/Properties/Settings.settings
+++ b/EZBlocker/EZBlocker/Properties/Settings.settings
@@ -17,5 +17,8 @@
     <Setting Name="ExitOnClose" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="DisableNotifs" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/EZBlocker/EZBlocker/Properties/Settings.settings
+++ b/EZBlocker/EZBlocker/Properties/Settings.settings
@@ -14,5 +14,8 @@
     <Setting Name="UserEducated" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ExitOnClose" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Previously, whenever Spotify closed, the app would wait 100 seconds, then send 3 of the same notification (honestly why I started looking at the code, so annoying and arbitrary), then quit.

Now, there is a checkbox to close the app when Spotify closes. I also turned the 100 seconds to a constant at the top of the program for easy access. I currently have it set to 20 seconds because I'm not certain if there was a reason for that 100 second delay or not. This can easily be changed. The app sends 1 notification now that it is closing.