### PR TITLE
Trying to fix muting when dragging sound tracks and pausing

### DIFF
--- a/EZBlocker/EZBlocker/EZBlockerMain.cs
+++ b/EZBlocker/EZBlocker/EZBlockerMain.cs
@@ -74,10 +74,6 @@ namespace EZBlocker
                             LogAction("/play/" + artist);
                         }
                     }
-                    else if (playingAd) // If here, means we were in an ad state, but Spotify was paused and ad is no longer playing
-                    {
-                        AudioUtils.SendPlayPause(hook.Handle);
-                    }
                     else
                     {
                         StatusLabel.Text = "Spotify is paused";

--- a/EZBlocker/EZBlocker/SpotifyHook.cs
+++ b/EZBlocker/EZBlocker/SpotifyHook.cs
@@ -38,7 +38,7 @@ namespace EZBlocker
 
         public bool IsAdPlaying()
         {
-            return IsPlaying() && !WindowName.Contains(" - ");
+            return IsPlaying() && !WindowName.Contains(" - ") && !WindowName.Equals("Drag");
         }
 
         public bool IsRunning()

--- a/EZBlocker/EZBlocker/SpotifyHook.cs
+++ b/EZBlocker/EZBlocker/SpotifyHook.cs
@@ -38,7 +38,7 @@ namespace EZBlocker
 
         public bool IsAdPlaying()
         {
-            return IsPlaying() && !WindowName.Contains(" - ") && !WindowName.Equals("Drag");
+            return IsPlaying() && !WindowName.Contains(" - ") && !WindowName.Equals("Drag") && !string.IsNullOrWhiteSpace(WindowName);
         }
 
         public bool IsRunning()


### PR DESCRIPTION
When I tried to drag a sound track ezblocker will mute spotify, as the WindowName will change to Drag. I added one condition so that it will hopefully not mute spotify on Dragging.

I've removed the following code automatically playing the ad, which solves the problem of pausing. 
`else if (playingAd) {  AudioUtils.SendPlayPause(hook.Handle);  } // If here, means we were in an ad state, but Spotify was paused and ad is no longer playing`

For my normal routine this works fine, as I really want to pause when I leave my seat.