### PR TITLE
Fix "Spotify not found" for the Windows Store version of Spotify

### DIFF
--- a/EZBlocker/EZBlocker/MediaHook.cs
+++ b/EZBlocker/EZBlocker/MediaHook.cs
@@ -43,7 +43,7 @@ namespace EZBlocker
             sessions.AddRange(SessionManager.GetSessions());
             foreach (GlobalSystemMediaTransportControlsSession session in sessions)
             {
-                if (session != null && session.SourceAppUserModelId == "Spotify.exe")
+                if (session != null && ((session.SourceAppUserModelId == "Spotify.exe") || (session.SourceAppUserModelId == "SpotifyAB.SpotifyMusic_zpdnekdrzrea0!Spotify")))
                 {
                     Debug.WriteLine("Registering " + session.GetHashCode());
                     if (unmute) AudioUtils.SetSpotifyMute(false);


### PR DESCRIPTION
This fixes the "Spotify not found" issue (#261) by checking for a media session name that matches what the Windows Store version of Spotify uses. I was not able to get the feature that starts Spotify on launch working, but the mute feature does. I did not the blocking of banner ads.

There's another pull request (#262) that attempts to fix this issue, but it only adds a default path to find where Spotify.exe is. I didn't find that this fixed the issue.